### PR TITLE
[substrate-sgx/sp-io] implement ed25519_verify

### DIFF
--- a/substrate-sgx/sp-io/with_sgx.rs
+++ b/substrate-sgx/sp-io/with_sgx.rs
@@ -270,8 +270,7 @@ pub mod crypto {
     }
 
     pub fn ed25519_verify(sig: &ed25519::Signature, msg: &[u8], pubkey: &ed25519::Public) -> bool {
-        warn!("crypto::ed25519_verify unimplemented");
-        true
+        ed25519::Pair::verify(sig, msg, pubkey)
     }
 
     /// Start verification extension.


### PR DESCRIPTION
implement ed25519 verify. As the signature checker defaults to it if the sr25519 signature check fails.

Before we defaulted to true...