### PR TITLE
Revert "quick fix blocknumber"

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,7 +1,7 @@
-//! The Substrate Node Template runtime for SGX.
+//! The Substrate Node Template runtime for SGX. 
 //! This is only meant to be used inside an SGX enclave with `#[no_std]`
-//!
-//! you should assemble your runtime to be used with your STF here
+//! 
+//! you should assemble your runtime to be used with your STF here 
 //! and get all your needed pallets in
 
 #![no_std]
@@ -9,36 +9,38 @@
 #![feature(structural_match)]
 #![feature(core_intrinsics)]
 #![feature(derive_eq)]
-// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
-#![recursion_limit = "256"]
 
-use pallet_transaction_payment::CurrencyAdapter;
-use sp_api::impl_runtime_apis;
-use sp_runtime::traits::{
-	AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, Saturating, Verify,
-};
-use sp_runtime::{create_runtime_str, generic, MultiSignature};
+// `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
+#![recursion_limit="256"]
+
 use sp_std::prelude::*;
+use sp_runtime::{
+	generic, create_runtime_str, MultiSignature
+};
+use sp_runtime::traits::{
+	BlakeTwo256, Block as BlockT, AccountIdLookup, Verify, IdentifyAccount, Saturating,
+};
+use sp_api::impl_runtime_apis;
 use sp_version::RuntimeVersion;
+use pallet_transaction_payment::CurrencyAdapter;
 
 // A few exports that help ease life for downstream crates.
-pub use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{KeyOwnerProofSystem, Randomness},
-	weights::{
-		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
-		IdentityFee, Weight,
-	},
-	StorageValue,
-};
-pub use pallet_balances::Call as BalancesCall;
-pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-pub use sp_runtime::{Perbill, Permill};
+pub use pallet_timestamp::Call as TimestampCall;
+pub use pallet_balances::Call as BalancesCall;
+pub use sp_runtime::{Permill, Perbill};
+pub use frame_support::{
+	construct_runtime, parameter_types, StorageValue,
+	traits::{KeyOwnerProofSystem, Randomness},
+	weights::{
+		Weight, IdentityFee,
+		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+	},
+};
 
-/// An index to a (sidechain) block.
-pub type BlockNumber = u64;
+/// An index to a block.
+pub type BlockNumber = u32;
 
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
@@ -82,6 +84,7 @@ pub mod opaque {
 	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 	/// Opaque block identifier type.
 	pub type BlockId = generic::BlockId<Block>;
+
 }
 
 pub const VERSION: RuntimeVersion = RuntimeVersion {
@@ -253,7 +256,7 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;


### PR DESCRIPTION
Only used for state storage (enoceded) -> BlockNumber does not matter